### PR TITLE
Deprecation notice

### DIFF
--- a/assign-doi-proxy-function/src/main/java/no/unit/nva/datacite/DataCiteMdsClientConfig.java
+++ b/assign-doi-proxy-function/src/main/java/no/unit/nva/datacite/DataCiteMdsClientConfig.java
@@ -2,6 +2,12 @@ package no.unit.nva.datacite;
 
 import nva.commons.utils.JacocoGenerated;
 
+/**
+ * Deprecated.
+ *
+ * See {@code no.unit.nva.doi.datacite.config.DataCiteConfigurationFactory} in assign-doi-datacite module.
+ */
+@Deprecated(forRemoval = true)
 public class DataCiteMdsClientConfig {
 
     private String institution;

--- a/assign-doi-proxy-function/src/main/java/no/unit/nva/datacite/DataCiteMdsClientConfig.java
+++ b/assign-doi-proxy-function/src/main/java/no/unit/nva/datacite/DataCiteMdsClientConfig.java
@@ -5,7 +5,7 @@ import nva.commons.utils.JacocoGenerated;
 /**
  * Deprecated.
  *
- * See {@code no.unit.nva.doi.datacite.config.DataCiteConfigurationFactory} in assign-doi-datacite module.
+ * <p>See {@code no.unit.nva.doi.datacite.config.DataCiteConfigurationFactory} in assign-doi-datacite module.
  */
 @Deprecated(forRemoval = true)
 public class DataCiteMdsClientConfig {

--- a/assign-doi-proxy-function/src/main/java/no/unit/nva/datacite/DataCiteMdsConnection.java
+++ b/assign-doi-proxy-function/src/main/java/no/unit/nva/datacite/DataCiteMdsConnection.java
@@ -15,6 +15,10 @@ import java.util.HashMap;
 
 import static nva.commons.utils.JsonUtils.objectMapper;
 
+/**
+ * Deprecated. See assign-doi-datacite module and new impl.
+ */
+@Deprecated(forRemoval = true)
 public class DataCiteMdsConnection {
 
     public static final String HTTPS = "https";


### PR DESCRIPTION
We want to use assign-doi-datacite module's DoiClient, so leaving a deprecation notice first.

Is `https://api.dev.nva.aws.unit.no/assign-doi` in use?
