### PR TITLE
Add events and sqs permissions for lamda role (NP-1706 NP-1707)

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -37,6 +37,44 @@ Parameters:
     Default: nvaEventBusArn
 
 Resources:
+  LambdaRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+            Action: sts:AssumeRole
+      Path: /
+      Policies:
+        - PolicyName: LambdaDefaults
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action:
+                  - logs:CreateLogGroup
+                  - logs:CreateLogStream
+                  - logs:PutLogEvents
+                  - sts:AssumeRole
+                  - sts:TagSession
+                Resource: "*"
+        - PolicyName: Events
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action:
+                  - events:*
+                  - sqs:SendMessage
+                  - sqs:ReceiveMessage
+                  - sqs:DeleteMessage
+                  - sqs:*
+                  - lambda:InvokeFunction
+                Resource: "*"
+
   DataCiteDraftDoiHandlerFunction:
     Type: AWS::Serverless::Function
     Properties:
@@ -51,6 +89,7 @@ Resources:
           DATACITE_CONFIG: !Ref DataCiteMdsConfigs
           DATACITE_HOST: !Ref DataCiteHost
           DATACITE_PORT: !Ref DataCitePort
+      Role: !GetAtt LambdaRole.Arn
       Events:
         EventBridgeEvent:
           Type: EventBridgeRule
@@ -95,6 +134,7 @@ Resources:
           DATACITE_CONFIG: !Ref DataCiteMdsConfigs
           DATACITE_HOST: !Ref DataCiteHost
           DATACITE_PORT: !Ref DataCitePort
+      Role: !GetAtt LambdaRole.Arn
       Events:
         EventBridgeEvent:
           Type: EventBridgeRule


### PR DESCRIPTION
Stack name `nva-doi-registry-client` should be updated to deploy from `develop` after this is merged. 

This closes https://github.com/BIBSYSDEV/NVA-infrastructure/pull/68 which I believe was incorrect, as it didn't help. This did.