### PR TITLE
Move hosts and ports to once config class

### DIFF
--- a/assign-doi-datacite/build.gradle
+++ b/assign-doi-datacite/build.gradle
@@ -3,6 +3,7 @@ plugins {
 }
 
 dependencies {
+    implementation project(":datacite-doi-commons")
 
     implementation libs.nva.core
     implementation libs.nva.json
@@ -18,6 +19,9 @@ dependencies {
 
 }
 
+
 test{
     environment "DOI_HOST", "example.doi.host.org"
+    environment "DATACITE_MDS_HOST","localhost"
+    environment "DATACITE_REST_HOST", "localhost"
 }

--- a/assign-doi-datacite/src/main/java/no/unit/nva/doi/datacite/connectionfactories/DataCiteConnectionFactory.java
+++ b/assign-doi-datacite/src/main/java/no/unit/nva/doi/datacite/connectionfactories/DataCiteConnectionFactory.java
@@ -1,7 +1,7 @@
 package no.unit.nva.doi.datacite.connectionfactories;
 
-import static no.unit.nva.doi.DataciteConfig.DATACITE_MDS_HOST;
-import static no.unit.nva.doi.DataciteConfig.DATACITE_REST_HOST;
+import static no.unit.nva.doi.DataciteConfig.DATACITE_MDS_URI;
+import static no.unit.nva.doi.DataciteConfig.DATACITE_REST_URI;
 import java.net.Authenticator;
 import java.net.InetAddress;
 import java.net.PasswordAuthentication;
@@ -45,7 +45,7 @@ public class DataCiteConnectionFactory {
      * @param configurationFactory DataCiteConfiguration Factory
      */
     public DataCiteConnectionFactory(DataCiteConfigurationFactory configurationFactory) {
-        this(HttpClient.newBuilder(), configurationFactory, DATACITE_MDS_HOST, DATACITE_REST_HOST);
+        this(HttpClient.newBuilder(), configurationFactory, DATACITE_MDS_URI, DATACITE_REST_URI);
     }
 
     /**

--- a/assign-doi-datacite/src/main/java/no/unit/nva/doi/datacite/connectionfactories/DataCiteConnectionFactory.java
+++ b/assign-doi-datacite/src/main/java/no/unit/nva/doi/datacite/connectionfactories/DataCiteConnectionFactory.java
@@ -1,5 +1,7 @@
 package no.unit.nva.doi.datacite.connectionfactories;
 
+import static no.unit.nva.doi.DataciteConfig.DATACITE_MDS_HOST;
+import static no.unit.nva.doi.DataciteConfig.DATACITE_REST_HOST;
 import java.net.Authenticator;
 import java.net.InetAddress;
 import java.net.PasswordAuthentication;
@@ -32,48 +34,34 @@ public class DataCiteConnectionFactory {
 
     public static final PasswordAuthentication DO_NOT_SEND_CREDENTIALS = null;
     private final PasswordAuthenticationFactory authenticationFactory;
-    private final String mdsApiHostName;
-    private final String restApiHostName;
-    private final int apiPort;
     private final Builder httpBuilder;
     private final DataCiteConfigurationFactory configurationFactory;
+    private final URI dataciteMdsHost;
+    private final URI dataciteRestUri;
 
     /**
      * Creates a dataciteConnectionFactory.
      *
      * @param configurationFactory DataCiteConfiguration Factory
-     * @param mdsApiHostName             the MDS API hostname
-     * @param restApiHostName             the REST API hostname
-     * @param apiPort              the API port
      */
-    public DataCiteConnectionFactory(DataCiteConfigurationFactory configurationFactory,
-                                     String mdsApiHostName,
-                                     String restApiHostName,
-                                     int apiPort) {
-        this(HttpClient.newBuilder(),
-            configurationFactory,
-                mdsApiHostName, restApiHostName, apiPort);
+    public DataCiteConnectionFactory(DataCiteConfigurationFactory configurationFactory) {
+        this(HttpClient.newBuilder(), configurationFactory, DATACITE_MDS_HOST, DATACITE_REST_HOST);
     }
 
     /**
      * Constructor for testing.
      *
      * @param httpBuilder HttpClient to override security configuration
-     * @param mdsApiHostName             the MDS API hostname
-     * @param restApiHostName             the REST API hostname
-     * @param apiPort     MDS API port
      */
     public DataCiteConnectionFactory(HttpClient.Builder httpBuilder,
                                      DataCiteConfigurationFactory configurationFactory,
-                                     String mdsApiHostName,
-                                     String restApiHostName,
-                                     int apiPort) {
+                                     URI dataciteMdsHost,
+                                     URI dataciteRestUri) {
         this.authenticationFactory = new PasswordAuthenticationFactory(configurationFactory);
-        this.mdsApiHostName = mdsApiHostName;
-        this.restApiHostName = restApiHostName;
-        this.apiPort = apiPort;
         this.httpBuilder = httpBuilder;
         this.configurationFactory = configurationFactory;
+        this.dataciteMdsHost = dataciteMdsHost;
+        this.dataciteRestUri = dataciteRestUri;
     }
 
     /**
@@ -85,13 +73,13 @@ public class DataCiteConnectionFactory {
      */
     public DataCiteMdsConnection getAuthenticatedMdsConnection(URI customerId) {
         HttpClient httpClient = getAuthenticatedHttpClientForDatacite(customerId);
-        return new DataCiteMdsConnection(httpClient, mdsApiHostName, apiPort);
+        return new DataCiteMdsConnection(httpClient, dataciteMdsHost);
     }
 
     public DataCiteRestConnection getAuthenticatedRestConnection(URI customerId) {
         HttpClient httpClient = getAuthenticatedHttpClientForDatacite(customerId);
         DataCiteMdsClientSecretConfig clientConfigWithCredentials = configurationFactory.getCredentials(customerId);
-        return new DataCiteRestConnection(httpClient, restApiHostName, apiPort, clientConfigWithCredentials);
+        return new DataCiteRestConnection(dataciteRestUri, httpClient, clientConfigWithCredentials);
     }
 
     public HttpClient getAuthenticatedHttpClientForDatacite(URI customerId) {
@@ -122,13 +110,13 @@ public class DataCiteConnectionFactory {
 
                 if (isCommunicatingTowardsConfiguredDataCiteApi(host, port)) {
                     return super.requestPasswordAuthenticationInstance(host,
-                        addr,
-                        port,
-                        protocol,
-                        prompt,
-                        scheme,
-                        url,
-                        reqType);
+                                                                       addr,
+                                                                       port,
+                                                                       protocol,
+                                                                       prompt,
+                                                                       scheme,
+                                                                       url,
+                                                                       reqType);
                 }
                 return DO_NOT_SEND_CREDENTIALS;
             }
@@ -139,7 +127,7 @@ public class DataCiteConnectionFactory {
             }
 
             private boolean isCommunicatingTowardsConfiguredDataCiteApi(String host, int port) {
-                return host.equalsIgnoreCase(mdsApiHostName) && port == apiPort;
+                return host.equalsIgnoreCase(dataciteMdsHost.getHost()) && port == dataciteMdsHost.getPort();
             }
         };
     }

--- a/assign-doi-datacite/src/main/java/no/unit/nva/doi/datacite/mdsclient/NoCredentialsForCustomerRuntimeException.java
+++ b/assign-doi-datacite/src/main/java/no/unit/nva/doi/datacite/mdsclient/NoCredentialsForCustomerRuntimeException.java
@@ -12,8 +12,4 @@ public class NoCredentialsForCustomerRuntimeException extends ClientRuntimeExcep
     public NoCredentialsForCustomerRuntimeException() {
         super(NO_CREDENTIALS_FOR_CUSTOMER);
     }
-
-    public NoCredentialsForCustomerRuntimeException(ClientException e) {
-        super(e);
-    }
 }

--- a/assign-doi-datacite/src/main/java/no/unit/nva/doi/datacite/mdsclient/NoCredentialsForCustomerRuntimeException.java
+++ b/assign-doi-datacite/src/main/java/no/unit/nva/doi/datacite/mdsclient/NoCredentialsForCustomerRuntimeException.java
@@ -1,6 +1,5 @@
 package no.unit.nva.doi.datacite.mdsclient;
 
-import no.unit.nva.doi.datacite.clients.exception.ClientException;
 import no.unit.nva.doi.datacite.clients.exception.ClientRuntimeException;
 import nva.commons.core.JacocoGenerated;
 

--- a/assign-doi-datacite/src/main/java/no/unit/nva/doi/datacite/restclient/DataCiteRestConnection.java
+++ b/assign-doi-datacite/src/main/java/no/unit/nva/doi/datacite/restclient/DataCiteRestConnection.java
@@ -3,42 +3,38 @@ package no.unit.nva.doi.datacite.restclient;
 import static nva.commons.core.attempt.Try.attempt;
 import java.io.IOException;
 import java.net.URI;
-import java.net.URISyntaxException;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpRequest.BodyPublishers;
 import java.net.http.HttpResponse;
 import java.util.Base64;
-import no.unit.nva.doi.datacite.restclient.models.DraftDoiDto;
 import no.unit.nva.doi.datacite.models.DataCiteMdsClientSecretConfig;
+import no.unit.nva.doi.datacite.restclient.models.DraftDoiDto;
+import nva.commons.core.paths.UriWrapper;
 
 public class DataCiteRestConnection {
 
-    public static final String HTTPS = "https";
     public static final String DOIS_PATH = "dois";
     public static final String JSON_API_CONTENT_TYPE = "application/vnd.api+json";
     public static final String CONTENT_TYPE = "Content-Type";
     public static final String ACCEPT = "Accept";
     public static final String COLON = ":";
     private static final String AUTHORIZATION_HEADER = "Authorization";
-    public static final String SEPARATOR = "/";
+    private final URI dataciteRestUri;
     private final HttpClient httpClient;
-    private final String host;
-    private final int port;
     private final DataCiteMdsClientSecretConfig configWithSecretes;
 
     /**
      * A DataCite connection for the RestApi.
      *
      * @param httpClient the httpclient to be used.
-     * @param host       the host address without scheme and path
-     * @param port       the port (for https 443)
      */
-    public DataCiteRestConnection(HttpClient httpClient, String host, int port,
-                                  DataCiteMdsClientSecretConfig configWithSecrets) {
+    public DataCiteRestConnection(
+        URI dataciteRestUri,
+        HttpClient httpClient,
+        DataCiteMdsClientSecretConfig configWithSecrets) {
+        this.dataciteRestUri = dataciteRestUri;
         this.httpClient = httpClient;
-        this.host = host;
-        this.port = port;
         this.configWithSecretes = configWithSecrets;
     }
 
@@ -64,17 +60,16 @@ public class DataCiteRestConnection {
     }
 
     public HttpResponse<String> getDoi(String id)
-            throws IOException, InterruptedException {
+        throws IOException, InterruptedException {
 
         HttpRequest postRequest = HttpRequest.newBuilder()
-                .uri(requestTargetUriToDoi(id))
-                .GET()
-                .header(ACCEPT, JSON_API_CONTENT_TYPE)
-                .headers(AUTHORIZATION_HEADER, authorizationString())
-                .build();
+            .uri(requestTargetUriToDoi(id))
+            .GET()
+            .header(ACCEPT, JSON_API_CONTENT_TYPE)
+            .headers(AUTHORIZATION_HEADER, authorizationString())
+            .build();
         return httpClient.send(postRequest, HttpResponse.BodyHandlers.ofString());
     }
-
 
     private String requestBodyContainingTheDoiPrefix() {
         DraftDoiDto bodyObject = DraftDoiDto.fromPrefix(configWithSecretes.getCustomerDoiPrefix());
@@ -92,34 +87,19 @@ public class DataCiteRestConnection {
         return "Basic " + Base64.getEncoder().encodeToString((username + COLON + password).getBytes());
     }
 
-
     private URI requestTargetUri() {
         return attempt(this::buildUri).orElseThrow();
     }
 
-    private URI buildUri() throws URISyntaxException {
-        return new URI(HTTPS,
-                null,
-                host,
-                port,
-                SEPARATOR + DOIS_PATH,
-                null,
-                null
-        );
+    private URI buildUri() {
+        return new UriWrapper(dataciteRestUri).addChild(DOIS_PATH).getUri();
     }
 
     private URI requestTargetUriToDoi(String id) {
         return attempt(() -> buildUriToDoi(id)).orElseThrow();
     }
 
-    private URI buildUriToDoi(String id) throws URISyntaxException {
-        return new URI(HTTPS,
-                null,
-                host,
-                port,
-                SEPARATOR + DOIS_PATH + SEPARATOR + id,
-                null,
-                null
-        );
+    private URI buildUriToDoi(String id) {
+        return new UriWrapper(dataciteRestUri).addChild(DOIS_PATH).addChild(id).getUri();
     }
 }

--- a/assign-doi-datacite/src/test/java/no/unit/nva/doi/datacite/clients/DataCiteClientSystemTest.java
+++ b/assign-doi-datacite/src/test/java/no/unit/nva/doi/datacite/clients/DataCiteClientSystemTest.java
@@ -89,7 +89,7 @@ class DataCiteClientSystemTest extends DataciteClientTestBase {
     private static final String doiPath = FORWARD_SLASH + DataCiteMdsConnection.DATACITE_PATH_DOI;
     private static final Integer MAX_WELL_KNOWN_PORT = 1024;
     private DataCiteMdsClientSecretConfig validSecretConfig;
-    private static final int MAX_PORT = 65000-MAX_WELL_KNOWN_PORT;
+    private static final int MAX_PORT = 65000 - MAX_WELL_KNOWN_PORT;
     private DataCiteClient doiClient;
     private WireMockServer wireMockServer;
     private URI mdsUri;
@@ -132,7 +132,7 @@ class DataCiteClientSystemTest extends DataciteClientTestBase {
             .sslContext(createInsecureSslContextTrustingEverything());
 
         DataCiteConnectionFactory mdsConnectionFactory =
-            new DataCiteConnectionFactory(httpClientBuilder, configurationFactory, mdsUri,restUri);
+            new DataCiteConnectionFactory(httpClientBuilder, configurationFactory, mdsUri, restUri);
         doiClient = new DataCiteClient(configurationFactory, mdsConnectionFactory);
     }
 

--- a/assign-doi-datacite/src/test/java/no/unit/nva/doi/datacite/clients/OnlineTests.java
+++ b/assign-doi-datacite/src/test/java/no/unit/nva/doi/datacite/clients/OnlineTests.java
@@ -20,9 +20,6 @@ import org.junit.jupiter.api.Test;
 
 public class OnlineTests {
 
-    public static final URI DATACITE_DRAFT_DOI_REST_API = URI.create("https://api.test.datacite.org/dois");
-    public static final URI DATACITE_DRAFT_DOI_MDS_API = URI.create("https://mds.test.datacite.org/doi");
-    public static final int DEFAULT_HTTPS_PORT = 443;
     private static final URI EXAMPLE_CUSTOMER_ID = URI.create("https://example.net/customer/id/4512");
     public static final String DRAFT = "draft";
 
@@ -31,10 +28,7 @@ public class OnlineTests {
     void createDoiAndVerifyStateTest() throws ClientException {
         DataCiteConfigurationFactory configFactory = mockConfigFactory();
 
-        var connectionFactory = new DataCiteConnectionFactory(configFactory,
-            DATACITE_DRAFT_DOI_MDS_API.getHost(),
-            DATACITE_DRAFT_DOI_REST_API.getHost(),
-            DEFAULT_HTTPS_PORT);
+        var connectionFactory = new DataCiteConnectionFactory(configFactory);
         var doiClient = new DataCiteClient(configFactory, connectionFactory);
         Doi doi = doiClient.createDoi(EXAMPLE_CUSTOMER_ID);
         assertThat(doi, is(not(nullValue())));

--- a/assign-doi-datacite/src/test/java/no/unit/nva/doi/datacite/mdsclient/DataCiteConnectionFactoryTest.java
+++ b/assign-doi-datacite/src/test/java/no/unit/nva/doi/datacite/mdsclient/DataCiteConnectionFactoryTest.java
@@ -1,6 +1,6 @@
 package no.unit.nva.doi.datacite.mdsclient;
 
-import static no.unit.nva.doi.DataciteConfig.DATACITE_MDS_HOST;
+import static no.unit.nva.doi.DataciteConfig.DATACITE_MDS_URI;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
@@ -79,11 +79,11 @@ class DataCiteConnectionFactoryTest {
     private PasswordAuthentication prompAuthenticatorForCredentials(Authenticator authenticator)
         throws UnknownHostException, MalformedURLException {
 
-        var uriInRequest = new UriWrapper(DATACITE_MDS_HOST).addChild("dummypath").getUri();
+        var uriInRequest = new UriWrapper(DATACITE_MDS_URI).addChild("dummypath").getUri();
 
         return authenticator
-            .requestPasswordAuthenticationInstance(DATACITE_MDS_HOST.getHost(), InetAddress.getLocalHost(),
-                                                   DATACITE_MDS_HOST.getPort(),
+            .requestPasswordAuthenticationInstance(DATACITE_MDS_URI.getHost(), InetAddress.getLocalHost(),
+                                                   DATACITE_MDS_URI.getPort(),
                                                    null,
                                                    "Please authenticate", "authenticationScheme",
                                                    uriInRequest.toURL(),

--- a/assign-doi-datacite/src/test/java/no/unit/nva/doi/datacite/mdsclient/DataCiteConnectionFactoryTest.java
+++ b/assign-doi-datacite/src/test/java/no/unit/nva/doi/datacite/mdsclient/DataCiteConnectionFactoryTest.java
@@ -1,5 +1,6 @@
 package no.unit.nva.doi.datacite.mdsclient;
 
+import static no.unit.nva.doi.DataciteConfig.DATACITE_MDS_HOST;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
@@ -15,11 +16,12 @@ import java.net.URI;
 import java.net.UnknownHostException;
 import java.util.Optional;
 import java.util.UUID;
-import no.unit.nva.doi.datacite.connectionfactories.DataCiteConnectionFactory;
 import no.unit.nva.doi.datacite.connectionfactories.DataCiteConfigurationFactory;
+import no.unit.nva.doi.datacite.connectionfactories.DataCiteConnectionFactory;
 import no.unit.nva.doi.datacite.connectionfactories.DataCiteMdsConfigValidationFailedException;
 import no.unit.nva.doi.datacite.models.DataCiteMdsClientConfig;
 import no.unit.nva.doi.datacite.models.DataCiteMdsClientSecretConfig;
+import nva.commons.core.paths.UriWrapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -32,8 +34,6 @@ class DataCiteConnectionFactoryTest {
     private static final URI EXAMPLE_CUSTOMER_ID = KNOWN_CUSTOMER_ID;
     private static final String EXAMPLE_MDS_USERNAME = "exampleUserNameForRepository";
     private static final String EXAMPLE_MDS_PASSWORD = UUID.randomUUID().toString();
-    private static final URI EXAMPLE_MDS_API_ENDPOINT = URI.create("https://example.net/api/mds/endpoint");
-    private static final URI EXAMPLE_REST_API_ENDPOINT = URI.create("https://example.net/api/rest/endpoint");
 
     private static final DataCiteMdsClientConfig MOCK_DATACITE_CONFIG = new DataCiteMdsClientSecretConfig(
         EXAMPLE_CUSTOMER_ID, EXAMPLE_CUSTOMER_DOI_PREFIX, EXAMPLE_MDS_USERNAME,
@@ -49,10 +49,7 @@ class DataCiteConnectionFactoryTest {
         configurationFactory = mock(DataCiteConfigurationFactory.class);
         when(configurationFactory.getConfig(KNOWN_CUSTOMER_ID)).thenReturn(MOCK_DATACITE_CONFIG);
 
-        sut = new DataCiteConnectionFactory(configurationFactory,
-            EXAMPLE_MDS_API_ENDPOINT.getHost(),
-            EXAMPLE_REST_API_ENDPOINT.getHost(),
-            EXAMPLE_MDS_API_ENDPOINT.getPort());
+        sut = new DataCiteConnectionFactory(configurationFactory);
     }
 
     @Test
@@ -68,7 +65,7 @@ class DataCiteConnectionFactoryTest {
             .authenticator();
         assertThat(authenticator.isPresent(), is(true));
         assertThrows(NoCredentialsForCustomerRuntimeException.class,
-            () -> prompAuthenticatorForCredentials(authenticator.get()));
+                     () -> prompAuthenticatorForCredentials(authenticator.get()));
     }
 
     @Test
@@ -81,13 +78,15 @@ class DataCiteConnectionFactoryTest {
 
     private PasswordAuthentication prompAuthenticatorForCredentials(Authenticator authenticator)
         throws UnknownHostException, MalformedURLException {
+
+        var uriInRequest = new UriWrapper(DATACITE_MDS_HOST).addChild("dummypath").getUri();
+
         return authenticator
-            .requestPasswordAuthenticationInstance(EXAMPLE_MDS_API_ENDPOINT.getHost(), InetAddress.getLocalHost(),
-                EXAMPLE_MDS_API_ENDPOINT.getPort(),
-                null,
-                "Please authenticate", "authenticationScheme",
-                URI.create(String.format("https://%s:%s/dummypath", EXAMPLE_MDS_API_ENDPOINT.getHost(),
-                    EXAMPLE_MDS_API_ENDPOINT.getPort())).toURL(),
-                RequestorType.SERVER);
+            .requestPasswordAuthenticationInstance(DATACITE_MDS_HOST.getHost(), InetAddress.getLocalHost(),
+                                                   DATACITE_MDS_HOST.getPort(),
+                                                   null,
+                                                   "Please authenticate", "authenticationScheme",
+                                                   uriInRequest.toURL(),
+                                                   RequestorType.SERVER);
     }
 }

--- a/assign-doi-datacite/src/test/java/no/unit/nva/doi/datacite/mdsclient/DataCiteMdsConnectionTest.java
+++ b/assign-doi-datacite/src/test/java/no/unit/nva/doi/datacite/mdsclient/DataCiteMdsConnectionTest.java
@@ -1,7 +1,7 @@
 package no.unit.nva.doi.datacite.mdsclient;
 
 
-import static no.unit.nva.doi.DataciteConfig.DATACITE_MDS_HOST;
+import static no.unit.nva.doi.DataciteConfig.DATACITE_MDS_URI;
 import static no.unit.nva.doi.datacite.mdsclient.DataCiteMdsConnection.MISSING_DATACITE_XML_ARGUMENT;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
@@ -144,7 +144,7 @@ public class DataCiteMdsConnectionTest {
     }
 
     private DataCiteMdsConnection createDataCiteMdsConnection() {
-        return new DataCiteMdsConnection(httpClient,DATACITE_MDS_HOST);
+        return new DataCiteMdsConnection(httpClient, DATACITE_MDS_URI);
     }
 
     private void stubHttpClientWithHttpResponse(String body) throws IOException, InterruptedException {

--- a/assign-doi-datacite/src/test/java/no/unit/nva/doi/datacite/mdsclient/DataCiteMdsConnectionTest.java
+++ b/assign-doi-datacite/src/test/java/no/unit/nva/doi/datacite/mdsclient/DataCiteMdsConnectionTest.java
@@ -1,5 +1,7 @@
 package no.unit.nva.doi.datacite.mdsclient;
 
+
+import static no.unit.nva.doi.DataciteConfig.DATACITE_MDS_HOST;
 import static no.unit.nva.doi.datacite.mdsclient.DataCiteMdsConnection.MISSING_DATACITE_XML_ARGUMENT;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
@@ -7,6 +9,7 @@ import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import java.io.IOException;
 import java.net.URISyntaxException;
@@ -17,8 +20,6 @@ import nva.commons.core.ioutils.IoUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatchers;
-import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
 
 public class DataCiteMdsConnectionTest {
 
@@ -27,27 +28,24 @@ public class DataCiteMdsConnectionTest {
     public static final String DATACITE_MDS_GET_DOI_RESPONSE = "dataciteMdsGetDoiResponse.txt";
     public static final String DATACITE_XML_RESOURCE_EXAMPLE = "dataciteXmlResourceExample.xml";
 
-    public static final String MOCK_HOST = "nva-mock.unit.no";
     public static final String MOCK_LANDING_PAGE_URL = "https://nva-mock.unit.no/123456789";
     public static final String MOCK_DOI_PREFIX = "prefix";
     public static final String MOCK_DOI = "prefix/suffix";
     public static final String MOCK_DATACITE_XML = "mock-xml";
     public static final String NO_METADATA = null;
-    private static final int MOCK_PORT = 8888;
-    @Mock
-    HttpClient httpClient;
 
-    @Mock
-    HttpResponse<String> httpResponse;
+    private HttpClient httpClient;
+    private HttpResponse<String> httpResponse;
 
     @BeforeEach
     public void setUp() {
-        MockitoAnnotations.initMocks(this);
+        httpClient = mock(HttpClient.class);
+        httpResponse = mock(HttpResponse.class);
     }
 
     @Test
     public void getMetadataSuccessfullyReturnsBodyInResponse()
-        throws IOException, URISyntaxException, InterruptedException {
+        throws IOException, InterruptedException {
         String body = IoUtils.stringFromResources(Path.of(DATACITE_XML_RESOURCE_EXAMPLE));
         stubHttpClientWithHttpResponse(body);
 
@@ -105,7 +103,8 @@ public class DataCiteMdsConnectionTest {
         DataCiteMdsConnection mockDataCiteMdsConnection = createDataCiteMdsConnection();
 
         NullPointerException actualException = assertThrows(NullPointerException.class,
-            () -> mockDataCiteMdsConnection.postMetadata(MOCK_DOI, NO_METADATA));
+                                                            () -> mockDataCiteMdsConnection.postMetadata(MOCK_DOI,
+                                                                                                         NO_METADATA));
         assertThat(actualException.getMessage(), is(equalTo(MISSING_DATACITE_XML_ARGUMENT)));
     }
 
@@ -145,7 +144,7 @@ public class DataCiteMdsConnectionTest {
     }
 
     private DataCiteMdsConnection createDataCiteMdsConnection() {
-        return new DataCiteMdsConnection(httpClient, MOCK_HOST, MOCK_PORT);
+        return new DataCiteMdsConnection(httpClient,DATACITE_MDS_HOST);
     }
 
     private void stubHttpClientWithHttpResponse(String body) throws IOException, InterruptedException {

--- a/buildSrc/src/main/groovy/nva.doiregistrar.service.java-common-conventions.gradle
+++ b/buildSrc/src/main/groovy/nva.doiregistrar.service.java-common-conventions.gradle
@@ -15,7 +15,6 @@ plugins {
 
 
 repositories {
-    mavenLocal()
     mavenCentral()
     maven { url 'https://jitpack.io' }
 }

--- a/buildSrc/src/main/groovy/nva.doiregistrar.service.java-common-conventions.gradle
+++ b/buildSrc/src/main/groovy/nva.doiregistrar.service.java-common-conventions.gradle
@@ -15,6 +15,7 @@ plugins {
 
 
 repositories {
+    mavenLocal()
     mavenCentral()
     maven { url 'https://jitpack.io' }
 }

--- a/datacite-delete-draft-doi-handler/src/main/java/no/unit/nva/datacite/handlers/DeleteDraftDoiAppEnv.java
+++ b/datacite-delete-draft-doi-handler/src/main/java/no/unit/nva/datacite/handlers/DeleteDraftDoiAppEnv.java
@@ -5,8 +5,7 @@ import nva.commons.core.JacocoGenerated;
 
 @JacocoGenerated
 public final class DeleteDraftDoiAppEnv {
-    
-    public static final String DATACITE_PORT = "DATACITE_PORT";
+
     public static final String DATACITE_MDS_HOST = "DATACITE_MDS_HOST";
     public static final String DATACITE_REST_HOST = "DATACITE_REST_HOST";
     public static final String CUSTOMER_SECRETS_SECRET_NAME = "CUSTOMER_SECRETS_SECRET_NAME";
@@ -25,11 +24,6 @@ public final class DeleteDraftDoiAppEnv {
     @JacocoGenerated
     public static String getDataCiteRestApiHost() {
         return getEnvValue(DATACITE_REST_HOST);
-    }
-
-    @JacocoGenerated
-    public static int getDataCitePort() {
-        return Integer.parseInt(getEnvValue(DATACITE_PORT));
     }
 
     @JacocoGenerated

--- a/datacite-delete-draft-doi-handler/src/main/java/no/unit/nva/datacite/handlers/DeleteDraftDoiHandler.java
+++ b/datacite-delete-draft-doi-handler/src/main/java/no/unit/nva/datacite/handlers/DeleteDraftDoiHandler.java
@@ -115,11 +115,7 @@ public class DeleteDraftDoiHandler
         DataCiteConfigurationFactory configFactory = new DataCiteConfigurationFactory(
             new SecretsReader(), getCustomerSecretsSecretName(), getCustomerSecretsSecretKey());
 
-        DataCiteConnectionFactory connectionFactory = new DataCiteConnectionFactory(
-            configFactory,
-            DeleteDraftDoiAppEnv.getDataCiteMdsApiHost(),
-            DeleteDraftDoiAppEnv.getDataCiteRestApiHost(),
-            DeleteDraftDoiAppEnv.getDataCitePort());
+        DataCiteConnectionFactory connectionFactory = new DataCiteConnectionFactory(configFactory);
         return new DataCiteClient(configFactory, connectionFactory);
     }
 }

--- a/datacite-doi-commons/build.gradle
+++ b/datacite-doi-commons/build.gradle
@@ -14,6 +14,10 @@ dependencies {
     testImplementation libs.bundles.testing
 }
 
+
 test{
     environment "API_HOST", "api.localhost.nva.aws.unit.no"
+
 }
+
+

--- a/datacite-doi-commons/build.gradle
+++ b/datacite-doi-commons/build.gradle
@@ -15,5 +15,5 @@ dependencies {
 }
 
 test{
-    environment "APPLICATION_HOST", "frontend.localhost.nva.aws.unit.no"
+    environment "API_HOST", "api.localhost.nva.aws.unit.no"
 }

--- a/datacite-doi-commons/src/main/java/no/unit/nva/doi/DataciteConfig.java
+++ b/datacite-doi-commons/src/main/java/no/unit/nva/doi/DataciteConfig.java
@@ -13,6 +13,7 @@ public final class DataciteConfig {
     private static final int DATACITE_PORT = readDatacitePort();
     public static final URI DATACITE_REST_URI = setupDataciteRestUri();
     public static final URI DATACITE_MDS_URI = setupDataciteMdsUri();
+
     private DataciteConfig() {
 
     }

--- a/datacite-doi-commons/src/main/java/no/unit/nva/doi/DataciteConfig.java
+++ b/datacite-doi-commons/src/main/java/no/unit/nva/doi/DataciteConfig.java
@@ -1,0 +1,41 @@
+package no.unit.nva.doi;
+
+import static nva.commons.core.attempt.Try.attempt;
+import java.net.URI;
+import nva.commons.core.Environment;
+import nva.commons.core.JacocoGenerated;
+import nva.commons.core.paths.UriWrapper;
+
+@JacocoGenerated
+public final class DataciteConfig {
+
+    private static final Environment ENVIRONMENT = new Environment();
+    private static final int DATACITE_PORT = readDatacitePort();
+    public static final URI DATACITE_REST_HOST = setupDataciteRestHost();
+    public static final URI DATACITE_MDS_HOST = setupDataciteMdsHost();
+    private DataciteConfig() {
+
+    }
+
+    private static Integer readDatacitePort() {
+        return ENVIRONMENT.readEnvOpt("DATACITE_PORT")
+            .map(Integer::parseInt)
+            .orElse(443);
+    }
+
+    private static URI setupDataciteMdsHost() {
+        return attempt(() -> ENVIRONMENT.readEnv("DATACITE_MDS_HOST"))
+            .map(DataciteConfig::newUri)
+            .orElseThrow();
+    }
+
+    private static URI setupDataciteRestHost() {
+        return attempt(() -> ENVIRONMENT.readEnv("DATACITE_REST_HOST"))
+            .map(DataciteConfig::newUri)
+            .orElseThrow();
+    }
+
+    private static URI newUri(String host) {
+        return UriWrapper.fromHost(host, DATACITE_PORT).getUri();
+    }
+}

--- a/datacite-doi-commons/src/main/java/no/unit/nva/doi/DataciteConfig.java
+++ b/datacite-doi-commons/src/main/java/no/unit/nva/doi/DataciteConfig.java
@@ -11,8 +11,8 @@ public final class DataciteConfig {
 
     private static final Environment ENVIRONMENT = new Environment();
     private static final int DATACITE_PORT = readDatacitePort();
-    public static final URI DATACITE_REST_HOST = setupDataciteRestHost();
-    public static final URI DATACITE_MDS_HOST = setupDataciteMdsHost();
+    public static final URI DATACITE_REST_URI = setupDataciteRestUri();
+    public static final URI DATACITE_MDS_URI = setupDataciteMdsUri();
     private DataciteConfig() {
 
     }
@@ -23,13 +23,13 @@ public final class DataciteConfig {
             .orElse(443);
     }
 
-    private static URI setupDataciteMdsHost() {
+    private static URI setupDataciteMdsUri() {
         return attempt(() -> ENVIRONMENT.readEnv("DATACITE_MDS_HOST"))
             .map(DataciteConfig::newUri)
             .orElseThrow();
     }
 
-    private static URI setupDataciteRestHost() {
+    private static URI setupDataciteRestUri() {
         return attempt(() -> ENVIRONMENT.readEnv("DATACITE_REST_HOST"))
             .map(DataciteConfig::newUri)
             .orElseThrow();

--- a/datacite-doi-commons/src/main/java/no/unit/nva/doi/LandingPageUtil.java
+++ b/datacite-doi-commons/src/main/java/no/unit/nva/doi/LandingPageUtil.java
@@ -12,14 +12,14 @@ public final class LandingPageUtil {
 
     public static final String PATH_TO_REGISTRATIONS = "registration";
     public static final String PATH_FOR_PUBLIC_PAGE_OF_REGISTRATION = "public";
-    public static final String APPLICATION_HOST = new Environment().readEnv("APPLICATION_HOST");
+    public static final String API_HOST = new Environment().readEnv("API_HOST");
 
     private LandingPageUtil() {
 
     }
 
     public static URI publicationFrontPage(SortableIdentifier publicationIdentifier) {
-        return UriWrapper.fromHost(APPLICATION_HOST)
+        return UriWrapper.fromHost(API_HOST)
             .addChild(PATH_TO_REGISTRATIONS)
             .addChild(publicationIdentifier.toString())
             .addChild(PATH_FOR_PUBLIC_PAGE_OF_REGISTRATION)

--- a/datacite-draft-doi-handler/build.gradle
+++ b/datacite-draft-doi-handler/build.gradle
@@ -5,6 +5,7 @@ plugins{
 dependencies {
     implementation project(":assign-doi-datacite")
     implementation project(":doi-commons")
+    implementation project(":datacite-doi-commons")
 
     implementation libs.nva.datamodel
     implementation libs.nva.doi

--- a/datacite-draft-doi-handler/src/main/java/no/unit/nva/datacite/handlers/DraftDoiAppEnv.java
+++ b/datacite-draft-doi-handler/src/main/java/no/unit/nva/datacite/handlers/DraftDoiAppEnv.java
@@ -6,30 +6,12 @@ import nva.commons.core.JacocoGenerated;
 @JacocoGenerated
 public final class DraftDoiAppEnv {
 
-    public static final String DATACITE_MDS_HOST = "DATACITE_MDS_HOST";
-    public static final String DATACITE_PORT = "DATACITE_PORT";
-    public static final String DATACITE_REST_HOST = "DATACITE_REST_HOST";
     public static final String CUSTOMER_SECRETS_SECRET_NAME = "CUSTOMER_SECRETS_SECRET_NAME";
     public static final String CUSTOMER_SECRETS_SECRET_KEY = "CUSTOMER_SECRETS_SECRET_KEY";
     private static final Environment ENVIRONMENT = new Environment();
 
     @JacocoGenerated
     private DraftDoiAppEnv() {
-    }
-
-    @JacocoGenerated
-    public static String getDataCiteMdsApiHost() {
-        return getEnvValue(DATACITE_MDS_HOST);
-    }
-
-    @JacocoGenerated
-    public static String getDataCiteRestApiHost() {
-        return getEnvValue(DATACITE_REST_HOST);
-    }
-
-    @JacocoGenerated
-    public static int getDataCitePort() {
-        return Integer.parseInt(getEnvValue(DATACITE_PORT));
     }
 
     @JacocoGenerated

--- a/datacite-draft-doi-handler/src/main/java/no/unit/nva/datacite/handlers/DraftDoiHandler.java
+++ b/datacite-draft-doi-handler/src/main/java/no/unit/nva/datacite/handlers/DraftDoiHandler.java
@@ -84,11 +84,7 @@ public class DraftDoiHandler extends DestinationsEventBridgeEventHandler<DoiUpda
         DataCiteConfigurationFactory configFactory = new DataCiteConfigurationFactory(
             new SecretsReader(), getCustomerSecretsSecretName(), getCustomerSecretsSecretKey());
 
-        DataCiteConnectionFactory connectionFactory = new DataCiteConnectionFactory(
-            configFactory,
-            DraftDoiAppEnv.getDataCiteMdsApiHost(),
-            DraftDoiAppEnv.getDataCiteRestApiHost(),
-            DraftDoiAppEnv.getDataCitePort());
+        DataCiteConnectionFactory connectionFactory = new DataCiteConnectionFactory(configFactory);
         return new DataCiteClient(configFactory, connectionFactory);
     }
 

--- a/datacite-findable-doi-handler/build.gradle
+++ b/datacite-findable-doi-handler/build.gradle
@@ -30,5 +30,5 @@ dependencies {
 }
 
 test{
-    environment "APPLICATION_HOST", "frontend.localhost.nva.unit.no"
+    environment "API_HOST", "api.localhost.nva.unit.no"
 }

--- a/datacite-findable-doi-handler/src/main/java/no/unit/nva/datacite/handlers/FindableDoiAppEnv.java
+++ b/datacite-findable-doi-handler/src/main/java/no/unit/nva/datacite/handlers/FindableDoiAppEnv.java
@@ -10,7 +10,6 @@ public final class FindableDoiAppEnv {
     public static final String DATACITE_MDS_HOST = "DATACITE_MDS_HOST";
     public static final String DATACITE_REST_HOST = "DATACITE_REST_HOST";
 
-    public static final String DATACITE_PORT = "DATACITE_PORT";
     public static final String CUSTOMER_SECRETS_SECRET_NAME = "CUSTOMER_SECRETS_SECRET_NAME";
     public static final String CUSTOMER_SECRETS_SECRET_KEY = "CUSTOMER_SECRETS_SECRET_KEY";
     private static final Environment ENVIRONMENT = new Environment();
@@ -29,10 +28,6 @@ public final class FindableDoiAppEnv {
         return getEnvValue(DATACITE_REST_HOST);
     }
 
-    @JacocoGenerated
-    public static int getDataCitePort() {
-        return Integer.parseInt(getEnvValue(DATACITE_PORT));
-    }
 
     @JacocoGenerated
     private static String getEnvValue(final String name) {

--- a/datacite-findable-doi-handler/src/main/java/no/unit/nva/datacite/handlers/FindableDoiEventHandler.java
+++ b/datacite-findable-doi-handler/src/main/java/no/unit/nva/datacite/handlers/FindableDoiEventHandler.java
@@ -67,7 +67,7 @@ public class FindableDoiEventHandler
         "Received request to set landing page (make findable) for DOI {} to landing page {} for {}";
     private static final String SUCCESSFULLY_MADE_DOI_FINDABLE = "Successfully handled request for Doi {} : {}";
     private static final Logger logger = LoggerFactory.getLogger(FindableDoiEventHandler.class);
-    public static final String APPLICATION_HOST = new Environment().readEnv("APPLICATION_HOST");
+    public static final String API_HOST = new Environment().readEnv("API_HOST");
 
     private final DoiClient doiClient;
 

--- a/datacite-findable-doi-handler/src/main/java/no/unit/nva/datacite/handlers/FindableDoiEventHandler.java
+++ b/datacite-findable-doi-handler/src/main/java/no/unit/nva/datacite/handlers/FindableDoiEventHandler.java
@@ -122,12 +122,8 @@ public class FindableDoiEventHandler
         DataCiteConfigurationFactory dataCiteConfigurationFactory = new DataCiteConfigurationFactory(
             new SecretsReader(), getCustomerSecretsSecretName(), getCustomerSecretsSecretKey());
 
-        DataCiteConnectionFactory dataCiteMdsConnectionFactory = new DataCiteConnectionFactory(
-            dataCiteConfigurationFactory,
-            FindableDoiAppEnv.getDataCiteMdsApiHost(),
-            FindableDoiAppEnv.getDataCiteRestApiHost(),
-            FindableDoiAppEnv.getDataCitePort()
-        );
+        DataCiteConnectionFactory dataCiteMdsConnectionFactory =
+            new DataCiteConnectionFactory(dataCiteConfigurationFactory);
 
         return new DataCiteClient(dataCiteConfigurationFactory, dataCiteMdsConnectionFactory);
     }

--- a/datacite-findable-doi-handler/src/test/java/no/unit/nva/datacite/handlers/FindableDoiEventHandlerTest.java
+++ b/datacite-findable-doi-handler/src/test/java/no/unit/nva/datacite/handlers/FindableDoiEventHandlerTest.java
@@ -207,7 +207,7 @@ public class FindableDoiEventHandlerTest {
     }
 
     private URI constructExpectedLandingPageUri(String identifier) {
-        return UriWrapper.fromHost(FindableDoiEventHandler.APPLICATION_HOST)
+        return UriWrapper.fromHost(FindableDoiEventHandler.API_HOST)
             .addChild("registration")
             .addChild(identifier)
             .addChild("public")

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 hamcrest = { strictly = '2.2' }
-nvaCommons = { strictly = '1.20.2' }
+nvaCommons = { strictly = '1.20.3' }
 jackson = { strictly = '2.13.0' }
 mockito = { strictly = '4.2.0' }
 junit = { strictly = '5.8.2' }

--- a/template.yaml
+++ b/template.yaml
@@ -12,9 +12,6 @@ Parameters:
   DataCiteRestHost:
     Type: 'AWS::SSM::Parameter::Value<String>'
     Default: dataCiteRestHost
-  DataCitePort:
-    Type: 'AWS::SSM::Parameter::Value<String>'
-    Default: dataCitePort
   EventBusName:
     Type: 'AWS::SSM::Parameter::Value<String>'
     Default: '/NVA/Events/EventsBusName'
@@ -122,7 +119,7 @@ Resources:
           CUSTOMER_SECRETS_SECRET_KEY: !Ref CustomerSecretsSecretKey
           DATACITE_REST_HOST: !Ref DataCiteRestHost
           DATACITE_MDS_HOST: !Ref DataCiteMdsHost
-          DATACITE_PORT: !Ref DataCitePort
+
       Events:
         EventBridgeEvent:
           Type: EventBridgeRule
@@ -167,7 +164,6 @@ Resources:
           CUSTOMER_SECRETS_SECRET_KEY: !Ref CustomerSecretsSecretKey
           DATACITE_REST_HOST: !Ref DataCiteRestHost
           DATACITE_MDS_HOST: !Ref DataCiteMdsHost
-          DATACITE_PORT: !Ref DataCitePort
       Events:
         EventBridgeEvent:
           Type: EventBridgeRule
@@ -209,7 +205,6 @@ Resources:
           CUSTOMER_SECRETS_SECRET_KEY: !Ref CustomerSecretsSecretKey
           DATACITE_REST_HOST: !Ref DataCiteRestHost
           DATACITE_MDS_HOST: !Ref DataCiteMdsHost
-          DATACITE_PORT: !Ref DataCitePort
       Events:
         EventBridgeEvent:
           Type: EventBridgeRule

--- a/template.yaml
+++ b/template.yaml
@@ -21,9 +21,9 @@ Parameters:
   EventBusArn:
     Type: 'AWS::SSM::Parameter::Value<String>'
     Default: '/NVA/Events/EventsBusArn'
-  ApplicationDomain:
+  ApiDomain:
     Type: 'AWS::SSM::Parameter::Value<String>'
-    Default: '/NVA/ApplicationDomain'
+    Default: '/NVA/ApiDomain'
   CustomerSecretsSecretName:
     Type: String
     Default: dataCiteCustomerSecrets
@@ -36,7 +36,7 @@ Globals:
     Timeout: 60
     Environment:
       Variables:
-        APPLICATION_HOST: !Ref ApplicationDomain
+        API_HOST: !Ref ApiDomain
 
 
 Resources:


### PR DESCRIPTION
An attempt to remove unnecessary parameters in order to simplify the configuration of the clients. Basically we are removing the HTTPS port configuration because it is always 443. 