### PR TITLE
Add UA to all external calls

### DIFF
--- a/assign-doi-datacite/src/main/java/no/unit/nva/doi/datacite/clients/DataCiteRestApiClient.java
+++ b/assign-doi-datacite/src/main/java/no/unit/nva/doi/datacite/clients/DataCiteRestApiClient.java
@@ -14,6 +14,7 @@ import no.unit.nva.doi.datacite.restclient.models.DoiStateDto;
 import no.unit.nva.doi.datacite.restclient.models.DraftDoiDto;
 import no.unit.nva.doi.models.Doi;
 import nva.commons.core.paths.UriWrapper;
+import nva.commons.core.useragent.UserAgent;
 
 public class DataCiteRestApiClient extends HttpSender {
 
@@ -65,6 +66,7 @@ public class DataCiteRestApiClient extends HttpSender {
                    .uri(requestTargetUriToDoi(doi))
                    .GET()
                    .header(ACCEPT, JSON_API_CONTENT_TYPE)
+                   .header(UserAgent.USER_AGENT, UserAgentUtil.create(this.getClass()))
                    .timeout(Duration.ofMillis(TIMEOUT))
                    .headers(AUTHORIZATION_HEADER, getBasicAuth(customer))
                    .build();
@@ -82,6 +84,7 @@ public class DataCiteRestApiClient extends HttpSender {
         return HttpRequest.newBuilder()
                    .uri(doiRequestUri())
                    .header(CONTENT_TYPE, JSON_API_CONTENT_TYPE)
+                   .header(UserAgent.USER_AGENT, UserAgentUtil.create(this.getClass()))
                    .POST(BodyPublishers.ofString(requestBodyContainingTheDoiPrefix(customerConfig)))
                    .headers(AUTHORIZATION_HEADER, getBasicAuth(customerConfig))
                    .timeout(Duration.ofMillis(TIMEOUT))

--- a/assign-doi-datacite/src/main/java/no/unit/nva/doi/datacite/clients/DataCiteRestApiClient.java
+++ b/assign-doi-datacite/src/main/java/no/unit/nva/doi/datacite/clients/DataCiteRestApiClient.java
@@ -66,7 +66,7 @@ public class DataCiteRestApiClient extends HttpSender {
                    .uri(requestTargetUriToDoi(doi))
                    .GET()
                    .header(ACCEPT, JSON_API_CONTENT_TYPE)
-                   .header(UserAgent.USER_AGENT, UserAgentUtil.create(this.getClass()))
+                   .header(UserAgent.USER_AGENT, UserAgentUtil.create(DataCiteRestApiClient.class))
                    .timeout(Duration.ofMillis(TIMEOUT))
                    .headers(AUTHORIZATION_HEADER, getBasicAuth(customer))
                    .build();
@@ -84,7 +84,7 @@ public class DataCiteRestApiClient extends HttpSender {
         return HttpRequest.newBuilder()
                    .uri(doiRequestUri())
                    .header(CONTENT_TYPE, JSON_API_CONTENT_TYPE)
-                   .header(UserAgent.USER_AGENT, UserAgentUtil.create(this.getClass()))
+                   .header(UserAgent.USER_AGENT, UserAgentUtil.create(DataCiteRestApiClient.class))
                    .POST(BodyPublishers.ofString(requestBodyContainingTheDoiPrefix(customerConfig)))
                    .headers(AUTHORIZATION_HEADER, getBasicAuth(customerConfig))
                    .timeout(Duration.ofMillis(TIMEOUT))

--- a/assign-doi-datacite/src/main/java/no/unit/nva/doi/datacite/clients/MdsClient.java
+++ b/assign-doi-datacite/src/main/java/no/unit/nva/doi/datacite/clients/MdsClient.java
@@ -122,7 +122,7 @@ public class MdsClient extends HttpSender {
                    .DELETE()
                    .uri(createUriForAccessingMetadata(doi))
                    .header(AUTHORIZATION_HEADER, customer.extractBasicAuthenticationString())
-                   .header(UserAgent.USER_AGENT, UserAgentUtil.create(this.getClass()))
+                   .header(UserAgent.USER_AGENT, UserAgentUtil.create(MdsClient.class))
                    .timeout(Duration.ofMillis(TIMEOUT))
                    .build();
     }
@@ -136,7 +136,7 @@ public class MdsClient extends HttpSender {
         return HttpRequest.newBuilder()
                    .DELETE()
                    .header(AUTHORIZATION_HEADER, customer.extractBasicAuthenticationString())
-                   .header(UserAgent.USER_AGENT, UserAgentUtil.create(this.getClass()))
+                   .header(UserAgent.USER_AGENT, UserAgentUtil.create(MdsClient.class))
                    .uri(createUriForAccessingDoi(doi))
                    .timeout(Duration.ofMillis(TIMEOUT))
                    .build();
@@ -158,7 +158,7 @@ public class MdsClient extends HttpSender {
         return HttpRequest.newBuilder()
                    .header(HttpHeaders.CONTENT_TYPE, APPLICATION_XML_CHARSET_UTF_8)
                    .header(AUTHORIZATION_HEADER, customer.extractBasicAuthenticationString())
-                   .header(UserAgent.USER_AGENT, UserAgentUtil.create(this.getClass()))
+                   .header(UserAgent.USER_AGENT, UserAgentUtil.create(MdsClient.class))
                    .uri(createUriForAccessingMetadata(doi))
                    .timeout(Duration.ofMillis(TIMEOUT))
                    .POST(HttpRequest.BodyPublishers.ofString(metadataDataCiteXml))
@@ -179,7 +179,7 @@ public class MdsClient extends HttpSender {
         return HttpRequest.newBuilder()
                    .header(HttpHeaders.CONTENT_TYPE, TEXT_PLAIN_CHARSET_UTF_8)
                    .header(AUTHORIZATION_HEADER, customer.extractBasicAuthenticationString())
-                   .header(UserAgent.USER_AGENT, UserAgentUtil.create(this.getClass()))
+                   .header(UserAgent.USER_AGENT, UserAgentUtil.create(MdsClient.class))
                    .timeout(Duration.ofMillis(TIMEOUT))
                    .uri(createUriForAccessingDoi(doi))
                    .PUT(HttpRequest.BodyPublishers.ofString(

--- a/assign-doi-datacite/src/main/java/no/unit/nva/doi/datacite/clients/MdsClient.java
+++ b/assign-doi-datacite/src/main/java/no/unit/nva/doi/datacite/clients/MdsClient.java
@@ -15,6 +15,7 @@ import no.unit.nva.doi.datacite.customerconfigs.CustomerConfigException;
 import no.unit.nva.doi.datacite.customerconfigs.CustomerConfigExtractor;
 import no.unit.nva.doi.models.Doi;
 import nva.commons.core.paths.UriWrapper;
+import nva.commons.core.useragent.UserAgent;
 import org.apache.http.HttpHeaders;
 import org.apache.http.HttpStatus;
 import org.slf4j.Logger;
@@ -92,6 +93,7 @@ public class MdsClient extends HttpSender {
                    .GET()
                    .header(HttpHeaders.ACCEPT, APPLICATION_XML_CHARSET_UTF_8)
                    .header(AUTHORIZATION_HEADER, customer.extractBasicAuthenticationString())
+                   .header(UserAgent.USER_AGENT, UserAgentUtil.create(MdsClient.class))
                    .uri(createUriForAccessingMetadata(doi))
                    .timeout(Duration.ofMillis(TIMEOUT))
                    .build();
@@ -120,6 +122,7 @@ public class MdsClient extends HttpSender {
                    .DELETE()
                    .uri(createUriForAccessingMetadata(doi))
                    .header(AUTHORIZATION_HEADER, customer.extractBasicAuthenticationString())
+                   .header(UserAgent.USER_AGENT, UserAgentUtil.create(this.getClass()))
                    .timeout(Duration.ofMillis(TIMEOUT))
                    .build();
     }
@@ -133,6 +136,7 @@ public class MdsClient extends HttpSender {
         return HttpRequest.newBuilder()
                    .DELETE()
                    .header(AUTHORIZATION_HEADER, customer.extractBasicAuthenticationString())
+                   .header(UserAgent.USER_AGENT, UserAgentUtil.create(this.getClass()))
                    .uri(createUriForAccessingDoi(doi))
                    .timeout(Duration.ofMillis(TIMEOUT))
                    .build();
@@ -154,6 +158,7 @@ public class MdsClient extends HttpSender {
         return HttpRequest.newBuilder()
                    .header(HttpHeaders.CONTENT_TYPE, APPLICATION_XML_CHARSET_UTF_8)
                    .header(AUTHORIZATION_HEADER, customer.extractBasicAuthenticationString())
+                   .header(UserAgent.USER_AGENT, UserAgentUtil.create(this.getClass()))
                    .uri(createUriForAccessingMetadata(doi))
                    .timeout(Duration.ofMillis(TIMEOUT))
                    .POST(HttpRequest.BodyPublishers.ofString(metadataDataCiteXml))
@@ -174,6 +179,7 @@ public class MdsClient extends HttpSender {
         return HttpRequest.newBuilder()
                    .header(HttpHeaders.CONTENT_TYPE, TEXT_PLAIN_CHARSET_UTF_8)
                    .header(AUTHORIZATION_HEADER, customer.extractBasicAuthenticationString())
+                   .header(UserAgent.USER_AGENT, UserAgentUtil.create(this.getClass()))
                    .timeout(Duration.ofMillis(TIMEOUT))
                    .uri(createUriForAccessingDoi(doi))
                    .PUT(HttpRequest.BodyPublishers.ofString(

--- a/assign-doi-datacite/src/main/java/no/unit/nva/doi/datacite/clients/UserAgentUtil.java
+++ b/assign-doi-datacite/src/main/java/no/unit/nva/doi/datacite/clients/UserAgentUtil.java
@@ -1,0 +1,25 @@
+package no.unit.nva.doi.datacite.clients;
+
+import nva.commons.core.Environment;
+import nva.commons.core.useragent.UserAgent;
+
+import java.net.URI;
+
+public final class UserAgentUtil {
+
+    public static final Environment ENVIRONMENT = new Environment();
+
+    private UserAgentUtil() {
+    }
+
+    public static String create(Class<?> clazz) {
+        return UserAgent.newBuilder()
+                .client(clazz)
+                .environment(ENVIRONMENT.readEnv("API_HOST"))
+                .email("support@sikt.no")
+                .repository(URI.create("https://github.com/BIBSYSDEV/nva-doi-registrar-client"))
+                .version("1.0")
+                .build()
+                .toString();
+    }
+}

--- a/assign-doi-datacite/src/test/java/no/unit/nva/doi/datacite/clients/DataCiteClientv2Test.java
+++ b/assign-doi-datacite/src/test/java/no/unit/nva/doi/datacite/clients/DataCiteClientv2Test.java
@@ -53,6 +53,7 @@ import no.unit.nva.doi.datacite.utils.FakeCustomerExtractorThrowingException;
 import no.unit.nva.doi.models.Doi;
 import no.unit.nva.stubs.WiremockHttpClient;
 import nva.commons.core.ioutils.IoUtils;
+import nva.commons.core.useragent.UserAgent;
 import nva.commons.logutils.LogUtils;
 import org.apache.http.HttpHeaders;
 import org.apache.http.HttpStatus;
@@ -87,6 +88,10 @@ public class DataCiteClientv2Test {
     private static final String doiPath = FORWARD_SLASH + MdsClient.DATACITE_PATH_DOI;
 
     private static final URI EXAMPLE_LANDING_PAGE = URI.create("https://example.net/nva/publication/203124124");
+    private static final String EXPECTED_USER_AGENT_REST = "DataCiteRestApiClient-api.localhost.nva.aws.unit.no/1.0 "
+            + "(https://github.com/BIBSYSDEV/nva-doi-registrar-client; mailto:support@sikt.no)";
+    private static final String EXPECTED_USER_AGENT_MDS = "MdsClient-api.localhost.nva.aws.unit.no/1.0 "
+            + "(https://github.com/BIBSYSDEV/nva-doi-registrar-client; mailto:support@sikt.no)";
     private DataCiteClientV2 client;
 
     private FakeCustomerExtractor customerConfigExtractor;
@@ -189,7 +194,8 @@ public class DataCiteClientv2Test {
         verify(1,
                postRequestedFor(urlEqualTo("/dois"))
                    .withBasicAuth(new BasicCredentials(CUSTOMER_USERNAME, CUSTOMER_PASSWORD))
-                   .withHeader(HEADER_CONTENT_TYPE, WireMock.equalTo(JSON_API_CONTENT_TYPE)));
+                   .withHeader(HEADER_CONTENT_TYPE, WireMock.equalTo(JSON_API_CONTENT_TYPE))
+                   .withHeader(UserAgent.USER_AGENT, WireMock.equalTo(EXPECTED_USER_AGENT_REST)));
         assertThat(actual, is(instanceOf(Doi.class)));
         var expectedCreatedServerDoi = createDoi("example.doi.host.org", DOI_PREFIX, randomSuffix);
         assertThat(actual.toIdentifier(), is(equalTo(expectedCreatedServerDoi.toIdentifier())));
@@ -424,7 +430,8 @@ public class DataCiteClientv2Test {
         verify(postRequestedFor(urlEqualTo(expectedPath))
                    .withBasicAuth(getExpectedAuthenticatedCredentials())
                    .withRequestBody(WireMock.equalTo(getValidMetadataPayload()))
-                   .withHeader(HEADER_CONTENT_TYPE, WireMock.equalTo(APPLICATION_XML_CHARSET_UTF_8)));
+                   .withHeader(HEADER_CONTENT_TYPE, WireMock.equalTo(APPLICATION_XML_CHARSET_UTF_8))
+                   .withHeader(UserAgent.USER_AGENT, WireMock.equalTo(EXPECTED_USER_AGENT_MDS)));
     }
 
     private BasicCredentials getExpectedAuthenticatedCredentials() {

--- a/datacite-delete-draft-doi-handler/src/main/java/no/unit/nva/datacite/handlers/doi/DeleteDraftDoiHandler.java
+++ b/datacite-delete-draft-doi-handler/src/main/java/no/unit/nva/datacite/handlers/doi/DeleteDraftDoiHandler.java
@@ -1,7 +1,8 @@
 package no.unit.nva.datacite.handlers.doi;
 
-import static com.amazonaws.util.SdkHttpUtils.urlDecode;
 import static nva.commons.core.attempt.Try.attempt;
+import static software.amazon.awssdk.utils.http.SdkHttpUtils.urlDecode;
+
 import com.amazonaws.services.lambda.runtime.Context;
 import java.net.HttpURLConnection;
 import java.net.URI;

--- a/doi-commons/src/main/java/no/unit/nva/datacite/commons/DataCiteMetadataResolver.java
+++ b/doi-commons/src/main/java/no/unit/nva/datacite/commons/DataCiteMetadataResolver.java
@@ -10,6 +10,7 @@ import java.net.http.HttpResponse;
 import java.net.http.HttpResponse.BodyHandlers;
 import nva.commons.core.JacocoGenerated;
 import nva.commons.core.attempt.Failure;
+import nva.commons.core.useragent.UserAgent;
 
 public class DataCiteMetadataResolver {
 

--- a/doi-commons/src/main/java/no/unit/nva/datacite/commons/DataCiteMetadataResolver.java
+++ b/doi-commons/src/main/java/no/unit/nva/datacite/commons/DataCiteMetadataResolver.java
@@ -10,7 +10,6 @@ import java.net.http.HttpResponse;
 import java.net.http.HttpResponse.BodyHandlers;
 import nva.commons.core.JacocoGenerated;
 import nva.commons.core.attempt.Failure;
-import nva.commons.core.useragent.UserAgent;
 
 public class DataCiteMetadataResolver {
 


### PR DESCRIPTION
- Adds user agent to all external calls (not the NVA-internal calls since the access to these is logged both by requester and receiver
- Tested this via the existing verifications, however, there is likely some discrepancy in the testing of e.g. delete, but not sure if validating the header is necessary since we are in essence re-testing the string creation functionality and the functionality of HttpRequest.
- For the environment information, I took the available "API_HOST" env-var, which is in my mind OK, since we just need some indicator as to which environment is calling — I would have preferred the simpler API_DOMAIN, but this is not available, nor is it any less or more useful or correct for identifying the "environment". The alternative is creating a new env-var to contain the info, or to do masses of work to get the account alias, which really adds nothing, except shortening the string we send. (This latter matter would have had some bearing if we had had thousands of calls per day)