### PR TITLE
fixing deletion of draft doi

### DIFF
--- a/assign-doi-datacite/src/main/java/no/unit/nva/doi/datacite/restclient/models/DoiStateDto.java
+++ b/assign-doi-datacite/src/main/java/no/unit/nva/doi/datacite/restclient/models/DoiStateDto.java
@@ -13,9 +13,9 @@ public class DoiStateDto {
     public static final String DOI = "doi";
 
     private final String doi;
-    private final String state;
+    private final State state;
 
-    public DoiStateDto(String doi, String state) {
+    public DoiStateDto(String doi, State state) {
         this.doi = doi;
         this.state = state;
     }
@@ -26,7 +26,7 @@ public class DoiStateDto {
     }
 
     @JacocoGenerated
-    public String getState() {
+    public State getState() {
         return state;
     }
 
@@ -41,8 +41,8 @@ public class DoiStateDto {
         JsonNode attributes = tree.path(DATA_FIELD).path(ATTRIBUTES_FIELD);
 
         String doi = attributes.path(DOI).textValue();
-        String state = attributes.path(STATE).textValue();
+        var state = attributes.path(STATE).textValue();
 
-        return new DoiStateDto(doi, state);
+        return new DoiStateDto(doi, State.fromValue(state));
     }
 }

--- a/assign-doi-datacite/src/main/java/no/unit/nva/doi/datacite/restclient/models/State.java
+++ b/assign-doi-datacite/src/main/java/no/unit/nva/doi/datacite/restclient/models/State.java
@@ -1,0 +1,25 @@
+package no.unit.nva.doi.datacite.restclient.models;
+
+import static java.util.Arrays.stream;
+
+public enum State {
+    DRAFT("draft"), REGISTERED("registered"), FINDABLE("findable");
+
+    public static final String UNKNOWN_DOI_STATE_MESSAGE = "Unknown doi state: ";
+    private final String value;
+
+    State(String value) {
+        this.value = value;
+    }
+
+    public static State fromValue(String value) {
+        return stream(values())
+                   .filter(state -> state.getValue().equalsIgnoreCase(value))
+                   .findAny()
+                   .orElseThrow(() -> new IllegalArgumentException(UNKNOWN_DOI_STATE_MESSAGE + value));
+    }
+
+    public String getValue() {
+        return value;
+    }
+}

--- a/assign-doi-datacite/src/test/java/no/unit/nva/doi/datacite/clients/DataCiteClientv2Test.java
+++ b/assign-doi-datacite/src/test/java/no/unit/nva/doi/datacite/clients/DataCiteClientv2Test.java
@@ -48,6 +48,7 @@ import no.unit.nva.doi.datacite.customerconfigs.CustomerConfig;
 import no.unit.nva.doi.datacite.customerconfigs.CustomerConfigException;
 import no.unit.nva.doi.datacite.restclient.models.DoiStateDto;
 import no.unit.nva.doi.datacite.restclient.models.DraftDoiDto;
+import no.unit.nva.doi.datacite.restclient.models.State;
 import no.unit.nva.doi.datacite.utils.FakeCustomerExtractor;
 import no.unit.nva.doi.datacite.utils.FakeCustomerExtractorThrowingException;
 import no.unit.nva.doi.models.Doi;
@@ -212,7 +213,7 @@ public class DataCiteClientv2Test {
         DoiStateDto actual = client.getDoi(customerUri, requestedDoi);
         assertThat(actual, is(instanceOf(DoiStateDto.class)));
         assertThat(actual.getDoi(), is(equalTo(requestedDoi.toIdentifier())));
-        assertThat(actual.getState(), is(equalTo(DRAFT)));
+        assertThat(actual.getState(), is(equalTo(State.DRAFT)));
     }
 
     @Test

--- a/assign-doi-datacite/src/test/java/no/unit/nva/doi/datacite/restclient/models/StateTest.java
+++ b/assign-doi-datacite/src/test/java/no/unit/nva/doi/datacite/restclient/models/StateTest.java
@@ -1,0 +1,13 @@
+package no.unit.nva.doi.datacite.restclient.models;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import org.junit.jupiter.api.Test;
+
+class StateTest {
+
+    @Test
+    void shouldThrowIllegalArgumentExceptionWhenStateIsUnknown() {
+        var state = "unknown";
+        assertThrows(IllegalArgumentException.class, () -> State.fromValue(state), "Unknown doi state: " + state);
+    }
+}

--- a/datacite-delete-draft-doi-handler/src/main/java/no/unit/nva/datacite/handlers/doi/DeleteDraftDoiHandler.java
+++ b/datacite-delete-draft-doi-handler/src/main/java/no/unit/nva/datacite/handlers/doi/DeleteDraftDoiHandler.java
@@ -9,6 +9,7 @@ import java.net.URI;
 import no.unit.nva.doi.DoiClient;
 import no.unit.nva.doi.datacite.clients.DataCiteClientV2;
 import no.unit.nva.doi.datacite.clients.exception.ClientException;
+import no.unit.nva.doi.datacite.restclient.models.State;
 import no.unit.nva.doi.models.Doi;
 import nva.commons.apigateway.ApiGatewayHandler;
 import nva.commons.apigateway.RequestInfo;
@@ -80,7 +81,7 @@ public class DeleteDraftDoiHandler extends ApiGatewayHandler<Void, Void> {
         var doiState = attempt(() -> doiClient.getDoi(customerId, doi))
                            .orElseThrow(failure ->
                                             handleFailure(failure.getException(), BAD_DATACITE_RESPONSE_MESSAGE));
-        if (!DOI_STATE_DRAFT.equalsIgnoreCase(doiState.getState())) {
+        if (!State.DRAFT.equals(doiState.getState())) {
             throw new BadMethodException(NOT_DRAFT_DOI_ERROR);
         }
     }

--- a/datacite-delete-draft-doi-handler/src/main/java/no/unit/nva/datacite/handlers/resource/ResourceDraftedForDeletionEventHandler.java
+++ b/datacite-delete-draft-doi-handler/src/main/java/no/unit/nva/datacite/handlers/resource/ResourceDraftedForDeletionEventHandler.java
@@ -7,6 +7,7 @@ import no.unit.nva.doi.DoiClient;
 import no.unit.nva.doi.datacite.clients.DataCiteClientV2;
 import no.unit.nva.doi.datacite.clients.exception.ClientException;
 import no.unit.nva.doi.datacite.restclient.models.DoiStateDto;
+import no.unit.nva.doi.datacite.restclient.models.State;
 import no.unit.nva.doi.models.Doi;
 import no.unit.nva.events.handlers.DestinationsEventBridgeEventHandler;
 import no.unit.nva.events.models.AwsEventBridgeDetail;
@@ -78,7 +79,7 @@ public class ResourceDraftedForDeletionEventHandler
             throw new RuntimeException(ERROR_GETTING_DOI_STATE, e);
         }
 
-        if (!DRAFT.equalsIgnoreCase(doiState.getState())) {
+        if (!State.DRAFT.equals(doiState.getState())) {
             throw new RuntimeException(NOT_DRAFT_DOI_ERROR);
         }
     }

--- a/datacite-delete-draft-doi-handler/src/test/java/no/unit/nva/datacite/handlers/resource/ResourceDraftedForDeletionEventHandlerTest.java
+++ b/datacite-delete-draft-doi-handler/src/test/java/no/unit/nva/datacite/handlers/resource/ResourceDraftedForDeletionEventHandlerTest.java
@@ -15,6 +15,7 @@ import java.io.IOException;
 import no.unit.nva.doi.DoiClient;
 import no.unit.nva.doi.datacite.clients.exception.ClientException;
 import no.unit.nva.doi.datacite.restclient.models.DoiStateDto;
+import no.unit.nva.doi.datacite.restclient.models.State;
 import nva.commons.core.ioutils.IoUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -34,7 +35,7 @@ public class ResourceDraftedForDeletionEventHandlerTest {
 
     @BeforeEach
     public void setUp() throws ClientException {
-        doiClient = doiClientReturningDoi(ResourceDraftedForDeletionEventHandler.DRAFT);
+        doiClient = doiClientReturningDoi(State.DRAFT);
         handler = new ResourceDraftedForDeletionEventHandler(doiClient);
         outputStream = new ByteArrayOutputStream();
         context = mock(Context.class);
@@ -77,7 +78,7 @@ public class ResourceDraftedForDeletionEventHandlerTest {
 
     @Test
     public void handleRequestThrowsExceptionWhenDoiIsNotInDraftState() throws ClientException, IOException {
-        doiClient = doiClientReturningDoi(NOT_DRAFT);
+        doiClient = doiClientReturningDoi(State.FINDABLE);
         handler = new ResourceDraftedForDeletionEventHandler(doiClient);
 
         try (var inputStream = IoUtils.inputStreamFromResources(DELETE_DRAFT_PUBLICATION_WITH_DOI_JSON)) {
@@ -90,20 +91,20 @@ public class ResourceDraftedForDeletionEventHandlerTest {
     private DoiClient doiClientReturningError() throws ClientException {
         DoiClient doiClient = mock(DoiClient.class);
         when(doiClient.getDoi(any(), any()))
-            .thenAnswer(invocation -> doiState(ResourceDraftedForDeletionEventHandler.DRAFT));
+            .thenAnswer(invocation -> doiState(State.DRAFT));
         doThrow(new RuntimeException(ResourceDraftedForDeletionEventHandler.ERROR_DELETING_DRAFT_DOI))
             .when(doiClient).deleteDraftDoi(any(), any());
         return doiClient;
     }
 
-    private DoiClient doiClientReturningDoi(String state) throws ClientException {
+    private DoiClient doiClientReturningDoi(State state) throws ClientException {
         DoiClient doiClient = mock(DoiClient.class);
         when(doiClient.getDoi(any(), any()))
             .thenAnswer(invocation -> doiState(state));
         return doiClient;
     }
 
-    private DoiStateDto doiState(String state) {
+    private DoiStateDto doiState(State state) {
         return new DoiStateDto(ResourceDraftedForDeletionEventHandlerTest.DOI_IDENTIFIER, state);
     }
 }

--- a/datacite-update-doi-handler/src/test/java/no/unit/nva/datacite/handlers/UpdateDoiEventHandlerTest.java
+++ b/datacite-update-doi-handler/src/test/java/no/unit/nva/datacite/handlers/UpdateDoiEventHandlerTest.java
@@ -266,18 +266,6 @@ public class UpdateDoiEventHandlerTest extends TestBase {
     }
 
     @Test
-    void shouldThrowBadGatewayWhenCouldNotFetchDoi1() throws IOException, ClientException {
-        var publicationIdentifier = SortableIdentifier.next().toString();
-        try (var inputStream = createDoiRequestInputStream(publicationIdentifier, VALID_SAMPLE_DOI,
-                                                           CUSTOMER_ID_IN_INPUT_EVENT, null)) {
-            when(doiClient.getDoi(any(), any())).thenReturn(null);
-            assertThrows(PublicationApiClientException.class, () -> {
-                updateDoiHandler.handleRequest(inputStream, outputStream, context);
-            });
-        }
-    }
-
-    @Test
     void shouldDoNothingWhenDoiToDeleteIsNotFindable() throws IOException, ClientException {
         var publicationIdentifier = SortableIdentifier.next().toString();
         var doi = Doi.fromUri(VALID_SAMPLE_DOI);
@@ -292,21 +280,6 @@ public class UpdateDoiEventHandlerTest extends TestBase {
                 CUSTOMER_ID_IN_INPUT_EVENT,
                 doi
             );
-        }
-    }
-
-    @Test
-    void shouldThrowRuntimeExceptionWhenNotPossibleToParseDoiMetadataWhenDeletingDoi() throws IOException,
-                                                                                           ClientException {
-        var publicationIdentifier = SortableIdentifier.next().toString();
-        try (var inputStream = createDoiRequestInputStream(publicationIdentifier, VALID_SAMPLE_DOI,
-                                                           CUSTOMER_ID_IN_INPUT_EVENT, null)) {
-            when(doiClient.getMetadata(any(), any())).thenReturn("");
-            mockGetDoiResponse(State.FINDABLE);
-            mockDataciteXmlGone(publicationIdentifier);
-
-            assertThrows(RuntimeException.class, () ->
-                updateDoiHandler.handleRequest(inputStream, outputStream, context));
         }
     }
 


### PR DESCRIPTION
We should handle Draft and Registered DOI when unpublishing publication. This solution will not throw exception when unpublishing non findable DOI. For now we dont do anything when unpublishing non findable DOI. 